### PR TITLE
feat: 내 이력서 관리 페이지 생성

### DIFF
--- a/src/app/modify-resume/page.tsx
+++ b/src/app/modify-resume/page.tsx
@@ -1,0 +1,19 @@
+import Content from '@/components/Content';
+import PageLayout from '../PageLayout';
+import { ResumeFormSection, TitleSection } from './sections';
+
+export default function ModifyResume() {
+  return (
+    <PageLayout
+      homeNav
+      className="flex h-screen max-w-screen justify-center"
+    >
+      <Content className="h-full flex-col items-center px-[40px] py-[64px]">
+        <div className="flex w-[50%] flex-col gap-[20px]">
+          <TitleSection />
+          <ResumeFormSection />
+        </div>
+      </Content>
+    </PageLayout>
+  );
+}

--- a/src/app/modify-resume/sections/ResumeFormSection.tsx
+++ b/src/app/modify-resume/sections/ResumeFormSection.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { ResumeForm } from '@/app/resume/components';
+import Button from '@/components/Button';
+import { PATH } from '@/constants';
+import { useRouter } from 'next/navigation';
+
+export default function ResumeFormSection() {
+  const router = useRouter();
+
+  const handleConfirmClick = () => {
+    router.push(PATH.HOME);
+  };
+
+  return (
+    <div className="flex flex-col">
+      <ResumeForm />
+      <div className="flex justify-end">
+        <Button
+          className="mt-[20px] mb-[48px]"
+          text="확인"
+          onClick={handleConfirmClick}
+          variant="primary"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/modify-resume/sections/TitleSection.tsx
+++ b/src/app/modify-resume/sections/TitleSection.tsx
@@ -1,0 +1,10 @@
+export default function TitleSection() {
+  return (
+    <div className="flex w-[50%] flex-col gap-[4px] pt-[40px]">
+      <p className="text-title3 font-semibold">내 이력서</p>
+      <p className="text-heading2 text-gray-80">
+        AI 면접 준비와 자기소개서 첨삭에 사용해요.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Issue
> #15 

## 작업 내용
- 내 이력서를 조회하고 수정하는 페이지를 생성했어요

## 스크린샷
<img width="1680" alt="스크린샷 2025-04-15 오후 4 23 16" src="https://github.com/user-attachments/assets/e598b813-4212-4084-b71f-a103be3162c0" />
<img width="1680" alt="스크린샷 2025-04-15 오후 4 23 35" src="https://github.com/user-attachments/assets/e025d4ca-5fd7-4775-a369-920e9fd55c49" />


## ETC
피그마에 있는 디자인에서 살짝 수정했어요. 회의에서 논의하고 보완 후 픽스 예정